### PR TITLE
fix: allow dependabot[bot] in claude-code-action

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -284,6 +284,7 @@ jobs:
         uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'dependabot[bot]'
           claude_args: |
             --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*),Bash(go:*),Bash(golangci-lint:*),Bash(gh:*)'
             --mcp-config '{"mcpServers": {"gopls": {"command": "gopls", "args": ["mcp"] }}}'


### PR DESCRIPTION
## Problem

The `claude-fix-dependabot-failures` job was consistently failing in ~6 seconds (before Claude could do anything) on all dependabot PRs.

**Root cause:** `claude-code-action` calls `checkHumanActor()` during agent mode setup, which checks the GitHub API for the actor's user type. Since `dependabot[bot]` has type `Bot` (not `User`), the action throws immediately:

> `Workflow initiated by non-human actor: dependabot (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.`

With `allowed_bots` unset (the default — empty string, no bots allowed), Claude never runs.

## Fix

Add `allowed_bots: 'dependabot[bot]'` to the action's `with:` block. This bypasses the human-actor check specifically for dependabot, allowing Claude to proceed with the fix attempt.

This is safe because dependabot PR content (`go.mod`/`go.sum` changes) is GitHub-managed, not attacker-controlled.

Fixes: #193 (and all future dependabot PRs that require code fixes)